### PR TITLE
feat: improve Esc keymap configuration in add_key interactive buffer

### DIFF
--- a/lua/i18n/add_key.lua
+++ b/lua/i18n/add_key.lua
@@ -714,7 +714,7 @@ function M.add_key_interactive()
     end
   end
 
-  map("<Esc>", cancel)
+  vim.keymap.set({ "n" }, "<Esc>", cancel, { buffer = buf, nowait = true, silent = true })
   map("<C-c>", cancel)
 
   local function save_and_close()


### PR DESCRIPTION
在输入模式下按 Esc 时，也会退出弹窗（主要是要按 Esc 关闭 blink 的提示），体验很不好，这里修改一下。