### PR TITLE
Parse named-export objects (export const X = {...})

### DIFF
--- a/lua/i18n/parser.lua
+++ b/lua/i18n/parser.lua
@@ -465,7 +465,7 @@ local function parse_js(content)
   local line_map = {}
   local col_map = {}
 
-  -- 查找 export default/module.exports 的对象节点
+  -- 查找 export default / module.exports / export const X = {...} 的对象节点
   local function find_export_object(node)
     for child in node:iter_children() do
       if child:type() == "export_statement" or child:type() == "expression_statement" then
@@ -476,6 +476,19 @@ local function parse_js(content)
             for g in grand:iter_children() do
               if g:type() == "object" then
                 return g
+              end
+            end
+          elseif grand:type() == "lexical_declaration" or grand:type() == "variable_declaration" then
+            -- named export, e.g. `export const messages = {...}` (optionally `as const`)
+            for decl in grand:iter_children() do
+              if decl:type() == "variable_declarator" then
+                local value = decl:field("value")[1]
+                if value and value:type() == "as_expression" then
+                  value = value:named_child(0)
+                end
+                if value and value:type() == "object" then
+                  return value
+                end
               end
             end
           end


### PR DESCRIPTION
## Problem

`parse_js` only extracts keys from `export default {...}` and `module.exports = {...}`. Codebases that organise translations as one **named export** per namespace module yield **zero keys**, because `find_export_object` walks past the `lexical_declaration` node without descending into it.

Example file that currently parses to nothing:

```ts
// locales/enUS/broadcasts.ts
export const broadcasts = {
  pageCreateTitle: "Create broadcast",
  list: { searchBroadcasts: "Search broadcasts..." },
} as const;
```

## Fix

Teach `find_export_object` to also descend into `lexical_declaration` / `variable_declaration` grandchildren of an `export_statement`, take the `variable_declarator`'s value, and unwrap a trailing `as const` (`as_expression`) before returning the object node. `export default` / `module.exports` behaviour is unchanged.

Paired with a source such as:

```lua
sources = {
  { pattern = 'locales/{locales}/{module}.ts', prefix = '{module}.' },
}
```

each file's name becomes the key namespace, so `broadcasts.pageCreateTitle` resolves to the string above.

## Testing

Against a real project laid out this way (59 named-export TS chunks, two locales): before the change `get_all_keys()` returned 0; after, it returns the full key set (734 keys here) with correct nested paths and lookups.